### PR TITLE
🩹 Fix descriptions sometimes being inaccurate on RTL languages

### DIFF
--- a/src/Scraper/AppInfoScraper.php
+++ b/src/Scraper/AppInfoScraper.php
@@ -72,7 +72,7 @@ class AppInfoScraper implements ParseHandlerInterface
         $country = $query[GPlayApps::REQ_PARAM_COUNTRY] ?? GPlayApps::DEFAULT_COUNTRY;
 
         $name = $appInfo[0][0];
-        $description = ScraperUtil::html2text($appInfo[72][0][1]);
+        $description = ScraperUtil::html2text($appInfo[12][0][0][1] ?? $appInfo[72][0][1]);
         $developer = $this->extractDeveloper($appInfo);
 
         $category = $this->extractCategory($appInfo[79][0][0] ?? []);


### PR DESCRIPTION
This fixes inaccurate descriptions being thrown in some cases when scraping apps in RTL languages.

This was notably an issue with Tumblr. I am not deep enough into my scrape yet to notice any other discrepancies, so I'm hoping this is it.

```php
// Requires the fix, otherwise it will return the English description.
$apps->getAppInfoForLocales('com.tumblr', ['ar']);

// Description is in the proper place.
$apps->getAppInfoForLocales('com.instagram.android', ['ar']);
```

Not sure what makes Tumblr unique in this scenario, but with a test of 1000 apps in 13 languages, this fix has proved to work as intended.